### PR TITLE
Update ja interwiki links; update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 .metadata*
 .project
 .settings
-AdminSettings.php
 LocalSettings.php
 StartProfiler.php
 cscope.files

--- a/extensions/ArchInterWiki.sql
+++ b/extensions/ArchInterWiki.sql
@@ -35,7 +35,7 @@ VALUES
 	('hu', 'https://wiki.archlinux.org/index.php/$1_(Magyar)', 1, 0),
 	('id', 'https://wiki.archlinux.org/index.php/$1_(Indonesia)', 1, 0),
 	('it', 'https://wiki.archlinux.org/index.php/$1_(Italiano)', 1, 0),
-	('ja', 'https://archlinuxjp.kusakata.com/wiki/$1', 1, 0),
+	('ja', 'https://wiki.archlinuxjp.org/index.php/$1', 1, 0),
 	('ko', 'https://wiki.archlinux.org/index.php/$1_(%ED%95%9C%EA%B5%AD%EC%96%B4)', 1, 0),
 	('lt', 'https://wiki.archlinux.org/index.php/$1_(Lietuvi%C5%A1kai)', 1, 0),
 	('nl', 'https://wiki.archlinux.org/index.php/$1_(Nederlands)', 1, 0),


### PR DESCRIPTION
The Japanese wiki moved to <https://wiki.archlinuxjp.org/>, see [discussion](https://wiki.archlinux.org/index.php/Help_talk:I18n#Moving_Japanese_pages_to_new_external_wiki); update ja interwiki links url.

 `AdminSettings.php` was deprecated in MediaWiki 1.23, see <https://www.mediawiki.org/wiki/Manual:AdminSettings.php>; remove from `.gitignore`.